### PR TITLE
core-container-manager with core-network

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "modclean": "",
     "nedb": "^1.8.0",
     "node-forge": "^0.6.45",
+    "promise-retry": "^1.1.1",
     "request": "^2.69.0",
     "selfsigned": "^1.8.0",
     "url": "^0.11.0",

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -577,12 +577,13 @@ async function addPermissionsFromSla(sla) {
 
 exports.connect = function () {
 	return new Promise((resolve, reject) => docker.ping(function (err, data) {
-		if (err) {
-			reject("Cant connect to docker!");
-			return;
-		}
-		resolve();
-	}))
+			if (err) {
+				reject("Cant connect to docker!");
+				return;
+			}
+			resolve();
+		}))
+		.then(() => bridge.identifySelf())
 		.then(() => bridge.identifyCM());
 };
 

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -108,6 +108,9 @@ const install = async function (sla) {
 			"UpdateConfig": {
 				"Parallelism": 1
 			},
+			"EndpointSpec": {
+				"Mode": "dnsrr"
+			},
 			"Networks": []
 		};
 
@@ -135,6 +138,9 @@ const install = async function (sla) {
 		}
 
 		saveSLA(sla);
+
+		//RELAY ON config.TaskTemplate.ContainerSpec.Env to find out communication peers
+		await bridge.connectEndpoints(containerConfig, dependentStoreConfigArray);
 
 		//UPDATE SERVICES
 		let dependentStoreConfig;

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -580,7 +580,8 @@ exports.connect = function () {
 			return;
 		}
 		resolve();
-	}));
+	}))
+		.then(() => bridge.identifyCM());
 };
 
 const listContainers = function () {

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -176,6 +176,7 @@ const install = async function (sla) {
 exports.install = install;
 
 const uninstall = async function (name) {
+	let networkConfig = await bridge.networkOfService(name);
 	return docker.getService(name).remove()
 		.then(() => docker.listSecrets({filters: {'label': ['databox.service.name=' + name]}}))
 		.then((secrets) => {
@@ -186,6 +187,7 @@ const uninstall = async function (name) {
 
 			return Promise.all(proms)
 		})
+		.then(() => bridge.postUninstall(name, networkConfig))
 		.then(() => db.deleteSLA(name, false));
 };
 exports.uninstall = uninstall;

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -140,7 +140,7 @@ const install = async function (sla) {
 		saveSLA(sla);
 
 		//RELAY ON config.TaskTemplate.ContainerSpec.Env to find out communication peers
-		await databoxNet.connectEndpoints(containerConfig, dependentStoreConfigArray);
+		await databoxNet.connectEndpoints(containerConfig, dependentStoreConfigArray, sla);
 
 		//UPDATE SERVICES
 		let dependentStoreConfig;

--- a/src/lib/databox-bridge-helper.js
+++ b/src/lib/databox-bridge-helper.js
@@ -1,6 +1,7 @@
-const request = require('request');
-const url     = require('url');
-const fs      = require('fs');
+const request      = require('request');
+const url          = require('url');
+const fs           = require('fs');
+const promiseRetry = require('promise-retry');
 
 const DATABOX_BRIDGE          = "bridge";
 const DATABOX_BRIDGE_ENDPOINT = "http://bridge:8080";
@@ -10,39 +11,65 @@ const CM_KEY = fs.readFileSync("/run/secrets/CM_KEY", {encoding: 'base64'});
 module.exports = function(docker) {
     let module = {};
 
+    /* create a network, get bridge's IP on that network, to serve as DNS resolver */
+    const preConfig = async function(sla) {
+        let networkName = sla.localContainerName + "-bridge";
+        let net = await createNetwork(networkName);
+
+        return new promiseRetry(function(retry) {
+            return net.connect({"Container": DATABOX_BRIDGE})
+                .then(() => net.inspect())
+                .then((data) => {
+                    let ipOnNet;
+                    for(var contId in data.Containers) {
+                        if (data.Containers[contId].Name === DATABOX_BRIDGE) {
+                            var cidr = data.Containers[contId].IPv4Address;
+                            ipOnNet = cidr.split('/')[0];
+                            break;
+                        }
+                    }
+
+                    if (ipOnNet === undefined) return Promise.reject("no DNS");
+                    else return Promise.resolve({"NetworkName": networkName, "DNS": ipOnNet});
+                }).catch(err => {
+                    retry(err);
+                });
+            }, {retries: 3, factor: 1});
+    };
+
     const connectEndpoints = async function(config, storeConfigArray) {
         let toConnect = [];
 
         let configPeers = peersOfEnvArray(config.TaskTemplate.ContainerSpec.Env);
         if (configPeers.lenght !== 0) toConnect.push(connectFor(config.Name, configPeers));
 
-        for (let storeConfig of storeConfigArray) {
-            let storePeers = peersOfEnvArray(storeConfig.TaskTemplate.ContainerSpec.Env);
-            if (storePeers.length !== 0) toConnect.push(connectFor(storeConfig.Name, storePeers));
+        if (storeConfigArray !== false) {
+            for (let storeConfig of storeConfigArray) {
+                let storePeers = peersOfEnvArray(storeConfig.TaskTemplate.ContainerSpec.Env);
+                if (storePeers.length !== 0) toConnect.push(connectFor(storeConfig.Name, storePeers));
+            }
         }
 
         return Promise.all(toConnect);
     };
 
-    /* create a network, get bridge's IP on that network, to serve as DNS resolver */
-    const preConfig = async function(sla) {
-        let networkName = sla.localContainerName + "-bridge";
-        let net = await createNetwork(networkName);
+    const identifyCM = async function() {
+        let opt = {filters: {"name": ["container-manager"]}};
 
-        return net.connect({"Container": DATABOX_BRIDGE})
-            .then(() => net.inspect())
-            .then((data) => {
-                let ipOnNet;
-                for(var contId in data.Containers) {
-                    if (data.Containers[contId].Name === DATABOX_BRIDGE) {
-                        var cidr = data.Containers[contId].IPv4Address;
-                        ipOnNet = cidr.split('/')[0];
-                        break;
-                    }
+        return docker.listContainers(opt)
+            .then(containers => {
+                if (containers.length == 0) {
+                    console.log("WARN: no CM found for bridge");
+                    return;
                 }
 
-                if (ipOnNet === undefined) return Promise.reject("no DNS");
-                else return Promise.resolve({"NetworkName": networkName, "DNS": ipOnNet});
+                if (containers.length > 1) {
+                    console.log("WARN: more than one CM found, taking the first");
+                }
+
+                const cm = containers[0];
+                let cmIP = cm.NetworkSettings.Networks["databox-system-net"].IPAddress;
+                return addPrivileged(cmIP);
             });
     };
 
@@ -51,13 +78,34 @@ module.exports = function(docker) {
             "Name": name,
             "Driver": "overlay",
             "Internal": true,
-            "Attachable": true,
-            "CheckDuplicate": true
+            "Attachable": true
         };
 
-        return docker.createNetwork(config)
-            .catch((err) => {
-                console.log("[ERROR] creating network", name, err);
+        return docker.listNetworks({filters: {"name": [config.Name]}})
+            .then(nets => {
+                if (nets.length === 0) {
+                    console.log("creating network ", config.Name);
+                    console.log(config);
+                    return docker.createNetwork(config)
+                        .catch((err) => {
+                            console.log("[ERROR] creating network ", name, err);
+                        });
+                } else {
+                    let filter_fn = net => {
+                        return net.Driver === config.Driver
+                            && net.Internal === config.Internal
+                            && net.Attachable === config.Attachable;
+                    };
+                    let filtered = nets.filter(filter_fn);
+
+                    if (filtered.length >= 1) {
+                        let existed = filtered[0];
+                        return Promise.resolve(docker.getNetwork(existed.Id));
+                    } else {
+                        let err = new Error('[Error] network ' + config.Name + ' already exists!');
+                        return Promise.reject(err);
+                    }
+                }
             });
     };
 
@@ -118,13 +166,43 @@ module.exports = function(docker) {
                         reject(err || body || "[connectFor] error: " + res.statusCode);
                         return;
                     }
-                    console.log("[connectFor] " + name + "DONE");
+                    console.log("[connectFor] " + name + " DONE");
                     resolve(body);
+                });
+        });
+    };
+
+    const addPrivileged = function(cmIP) {
+        return new Promise((resolve, reject) => {
+            const data = {
+                src_ip: cmIP
+            };
+
+            const options = {
+                url: DATABOX_BRIDGE_ENDPOINT + "/privileged",
+                method: 'POST',
+                body: data,
+                json: true,
+                headers: {
+                    'x-api-key': CM_KEY
+                }
+            };
+            console.log(options);
+            request(
+                options,
+                function(err, res, body) {
+                    if (err || (res.statusCode < 200 || res.statusCode >= 300)) {
+                        console.log(err || body || "[addPrivileged] error: " + res.statusCode);
+                    } else {
+                        console.log("[addPrivileged] DONE");
+                    }
+                    resolve();
                 });
         });
     };
 
     module.preConfig        = preConfig;
     module.connectEndpoints = connectEndpoints;
+    module.identifyCM      = identifyCM;
     return module;
 };

--- a/src/lib/databox-bridge-helper.js
+++ b/src/lib/databox-bridge-helper.js
@@ -1,0 +1,46 @@
+const DATABOX_BRIDGE = "bridge";
+const DATABOX_BRIDGE_ENDPOINT = "https://bridge:8080";
+
+module.exports = function(docker) {
+    var module = {};
+
+    /* create a network, get bridge's IP on that network, to serve as DNS resolver */
+    const preConfig = async function(sla) {
+        let networkName = sla.localContainerName + "-bridge";
+        let net = await createNetwork(networkName);
+
+        return net.connect({"Container": DATABOX_BRIDGE})
+            .then(() => net.inspect())
+            .then((data) => {
+                let ipOnNet;
+                for(var contId in data.Containers) {
+                    if (data.Containers[contId].Name === DATABOX_BRIDGE) {
+                        var cidr = data.Containers[contId].IPv4Address;
+                        ipOnNet = cidr.split('/')[0];
+                        break;
+                    }
+                }
+
+                if (ipOnNet === undefined) return Promise.reject("no DNS");
+                else return Promise.resolve({"NetworkName": networkName, "DNS": ipOnNet});
+            });
+    };
+
+    const createNetwork = async function(name) {
+        let config = {
+            "Name": name,
+            "Driver": "overlay",
+            "Internal": true,
+            "Attachable": true,
+            "CheckDuplicate": true
+        };
+
+        return docker.createNetwork(config)
+            .catch((err) => {
+                console.log("[ERROR] creating network", name, err);
+            });
+    };
+
+    module.preConfig = preConfig;
+    return module;
+};

--- a/src/lib/databox-bridge-helper.js
+++ b/src/lib/databox-bridge-helper.js
@@ -124,8 +124,8 @@ module.exports = function(docker) {
 
                 if (containers.length === 0) {
                     return Promise.resolve(docker.getNetwork(config.Network))
-                        .then((net) => net.disconnect({"Container": DATABOX_BRIDGE}))
-                        .then((net) => removeNetwork(net, config.Network))
+                        //.then((net) => net.disconnect({"Container": DATABOX_BRIDGE}))
+                        //.then((net) => removeNetwork(net, config.Network))
                         .then(() => console.log("network ", config.Network, " removed"))
                         .catch((err) => console.log(err));
                 } else {

--- a/src/lib/databox-bridge-helper.js
+++ b/src/lib/databox-bridge-helper.js
@@ -14,11 +14,11 @@ module.exports = function(docker) {
     /* create a network, get bridge's IP on that network, to serve as DNS resolver */
     const preConfig = async function(sla) {
         let networkName = sla.localContainerName + "-bridge";
-        let net = await createNetwork(networkName);
+        let net = await getNetwork(networkName);
 
-        return new promiseRetry(function(retry) {
-            return net.connect({"Container": DATABOX_BRIDGE})
-                .then(() => net.inspect())
+        return new promiseRetry((retry, number) => {
+            /* in case network is existed, inspect first, if no bridge spotted then connect */
+            return net.inspect()
                 .then((data) => {
                     let ipOnNet;
                     for(var contId in data.Containers) {
@@ -29,8 +29,17 @@ module.exports = function(docker) {
                         }
                     }
 
-                    if (ipOnNet === undefined) return Promise.reject("no DNS");
-                    else return Promise.resolve({"NetworkName": networkName, "DNS": ipOnNet});
+                    if (ipOnNet === undefined) {
+                        /* newly created network, connect then retry */
+                        return net.connect({"Container": DATABOX_BRIDGE})
+                            .then(() => {
+                                console.log(DATABOX_BRIDGE + " connected on " + networkName);
+                                retry();
+                            })
+                            .catch(err => retry(err));
+                    } else {
+                        return {"NetworkName": networkName, "DNS": ipOnNet};
+                    }
                 }).catch(err => {
                     retry(err);
                 });
@@ -73,7 +82,65 @@ module.exports = function(docker) {
             });
     };
 
-    const createNetwork = async function(name) {
+    const networkOfService = function(service) {
+        let config = {};
+        return docker.getService(service).inspect()
+            .then((data) => {
+                let networks = data.Spec.Networks;
+                if (networks.length !== 1) {
+                    console.log(service + " on " + networks.length + " networks");
+                }
+
+                config["Network"] = networks[0].Target;
+                return config["Network"];
+            })
+            .then((net) => {
+                return docker.getNetwork(net).inspect()
+                    .then((data) => {
+                        for (let contId in data.Containers) {
+                            if (toServiceName(data.Containers[contId].Name) === service) {
+                                return data.Containers[contId].IPv4Address;
+                            }
+                        }
+                    });
+            })
+            .then((ip) => {
+                config["IP"] = ip;
+                console.log(config);
+                return config;
+            });
+    };
+
+    const postUninstall = async function(service, config) {
+        return docker.getNetwork(config.Network).inspect()
+            .then((data) => {
+                let containers = [];
+                for (let contId in data.Containers) {
+                    let sname = toServiceName(data.Containers[contId].Name);
+                    if (sname !== service && sname !== DATABOX_BRIDGE) {
+                        containers.push(data.Containers[contId].Name);
+                    }
+                }
+
+                if (containers.length === 0) {
+                    return Promise.resolve(docker.getNetwork(config.Network))
+                        .then((net) => net.disconnect({"Container": DATABOX_BRIDGE}))
+                        .then((net) => removeNetwork(net, config.Network))
+                        .then(() => console.log("network ", config.Network, " removed"))
+                        .catch((err) => console.log(err));
+                } else {
+                    for (let c of containers) {
+                        console.log(c + " still on the network");
+                    };
+                    return;
+                }
+            })
+            .then(() => disconnectFor(service, config.IP))
+            .catch(err => console.log("[Bridge] postUninstall error ", err));
+
+    };
+
+    const getNetwork = async function(name) {
         let config = {
             "Name": name,
             "Driver": "overlay",
@@ -100,6 +167,7 @@ module.exports = function(docker) {
 
                     if (filtered.length >= 1) {
                         let existed = filtered[0];
+                        console.log("using existed network");
                         return Promise.resolve(docker.getNetwork(existed.Id));
                     } else {
                         let err = new Error('[Error] network ' + config.Name + ' already exists!');
@@ -123,7 +191,7 @@ module.exports = function(docker) {
                 (key.startsWith("DATABOX_") && key.endsWith("_ENDPOINT"))) {
                 //arbiter, export service, and dependent stores
                 hostname = url.parse(value).hostname;
-                if (!peers.includes[hostname]) peers.push(hostname);
+                if (!peers.includes(hostname)) peers.push(hostname);
             } else if (key.startsWith("DATASOURCE_")) {
                 //datasources
                 //multiple sources may in the same store, checkou duplication
@@ -158,7 +226,6 @@ module.exports = function(docker) {
                     'x-api-key': CM_KEY
                 }
             };
-            console.log(options);
             request(
                 options,
                 function(err, res, body) {
@@ -172,8 +239,37 @@ module.exports = function(docker) {
         });
     };
 
-    const addPrivileged = function(cmIP) {
+    const disconnectFor = function(name, ip) {
         return new Promise((resolve, reject) => {
+            const data = {
+                name: name,
+                ip: ip
+            };
+
+            const options = {
+                url: DATABOX_BRIDGE_ENDPOINT + "/disconnect",
+                method: 'POST',
+                body: data,
+                json: true,
+                headers: {
+                    'x-api-key': CM_KEY
+                }
+            };
+            request(
+                options,
+                function(err, res, body) {
+                    if (err || (res.statusCode < 200 || res.statusCode >= 300)) {
+                        reject(err || new Error(body || "[disconnectFor] error: " + res.statusCode));
+                        return;
+                    }
+                    console.log("[disconnectFor] " + name + " DONE");
+                    resolve(body);
+                });
+        });
+    };
+
+    const addPrivileged = function(cmIP) {
+        return new promiseRetry((retry) => {
             const data = {
                 src_ip: cmIP
             };
@@ -184,25 +280,46 @@ module.exports = function(docker) {
                 body: data,
                 json: true,
                 headers: {
-                    'x-api-key': CM_KEY
+                   'x-api-key': CM_KEY
                 }
             };
-            console.log(options);
             request(
                 options,
                 function(err, res, body) {
                     if (err || (res.statusCode < 200 || res.statusCode >= 300)) {
-                        console.log(err || body || "[addPrivileged] error: " + res.statusCode);
+                        retry(err || new Error(body || "[addPrivileged] error: " + res.statusCode));
                     } else {
                         console.log("[addPrivileged] DONE");
                     }
-                    resolve();
+                    return;}
+            );
+        }, {retries: 3, factor: 1});
+    };
+
+    const toServiceName = function(name) {
+        let dot = name.indexOf('.');
+        if (dot === -1) return name;
+        else return name.substring(0, dot);
+    }
+
+    const removeNetwork = function(net) {
+        const retryLimit = 3;
+        const tryRemove = (count) => {
+            return net.remove()
+                .catch(err => {
+                    return count >= retryLimit
+                        ? Promise.reject(new Error("can't remove network"))
+                        : setTimeout(() => tryRemove(count + 1), 1500);
                 });
-        });
+        };
+
+        return tryRemove(1);
     };
 
     module.preConfig        = preConfig;
     module.connectEndpoints = connectEndpoints;
-    module.identifyCM      = identifyCM;
+    module.identifyCM       = identifyCM;
+    module.networkOfService = networkOfService;
+    module.postUninstall    = postUninstall;
     return module;
 };

--- a/src/lib/databox-network-helper.js
+++ b/src/lib/databox-network-helper.js
@@ -17,7 +17,9 @@ module.exports = function(docker) {
     /* create a network, get core-network's IP on that network, to serve as DNS resolver */
     const preConfig = async function(sla) {
         let networkName = sla.localContainerName + "-network";
-        let net = await getNetwork(networkName);
+
+        let internal = sla['databox-type'] === 'driver' ? false : true;
+        let net = await getNetwork(networkName, internal);
 
         return new promiseRetry((retry, number) => {
             /* in case network is existed, inspect first, if no network spotted then connect */
@@ -175,11 +177,11 @@ module.exports = function(docker) {
 
     };
 
-    const getNetwork = async function(name) {
+    const getNetwork = async function(name, internal) {
         let config = {
             "Name": name,
             "Driver": "overlay",
-            "Internal": true,
+            "Internal": internal,
             "Attachable": true
         };
 


### PR DESCRIPTION
#### changes in brief:
- when starts up, notify bridge about CM's IP, *(this IP is privileged in terms of resolving other services' names, and making contacts to them)*
- when install an app/driver: ensure a dedicated network is there before hand *(created or use existed)*, and bridge is connected, using bridge's IP on that net to configure their DNS, extract all communicating endpoints from SLA, then call on bridge to make the configuration
- when uninstall an app/driver/store: clear states in bridge about the related configurations

#### more to come:
- [x] maybe delete the dedicated network after the user removes all the services on it *(tried, but make the bridge crash somehow when reinstall the same service again)*