### PR TITLE
for service restart

### DIFF
--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -47,9 +47,8 @@ let getRegistryUrlFromSLA = function (sla) {
 				registryUrl = sla.registry + "/";
 			} else {
 				//default to databox systems
-				//console.log("Using databoxsystems registry");
-				//registryUrl = "databoxsystems/";
-				registryUrl = "";
+				console.log("Using databoxsystems registry");
+				registryUrl = "databoxsystems/";
 			}
 		}
 	}

--- a/src/lib/databox-network-helper.js
+++ b/src/lib/databox-network-helper.js
@@ -177,6 +177,38 @@ module.exports = function(docker) {
 
     };
 
+
+    const serviceRestart = async function(sname, old_ip, new_ip) {
+        return new Promise((resolve, reject) => {
+            const data = {
+                name: sname,
+                old_ip: old_ip,
+                new_ip: new_ip,
+            };
+
+            const options = {
+                url: DATABOX_NETWORK_ENDPOINT + "/restart",
+                method: 'POST',
+                body: data,
+                agent: https_agent,
+                json: true,
+                headers: {
+                    'x-api-key': CM_KEY
+                }
+            };
+            request(
+                options,
+                function(err, res, body) {
+                    if (err || (res.statusCode < 200 || res.statusCode >= 300)) {
+                        reject(err || body || "[serviceRestart] error: " + res.statusCode);
+                        return;
+                    }
+                    console.log("[serviceRestart] " + sname + " DONE");
+                    resolve();
+                });
+        });
+    }
+
     const getNetwork = async function(name, internal) {
         let config = {
             "Name": name,
@@ -363,5 +395,6 @@ module.exports = function(docker) {
     module.identifySelf     = identifySelf;
     module.networkOfService = networkOfService;
     module.postUninstall    = postUninstall;
+    module.serviceRestart   = serviceRestart;
     return module;
 };


### PR DESCRIPTION
for issue https://github.com/me-box/databox/issues/230
together with [core-network#restart-app](https://github.com/me-box/core-network/tree/restart-app)

before killing the container, get it's IP as `old_ip`
after the restart, get the `new_ip`, if different, call on core-network to do the substitution

seems to still have some timing issue in this solution, as the container's new IP is available, but before states within core-network is updated, traffic will not be able to get through

tested by restarting both app and driver *(for os-monitor)*
